### PR TITLE
recodage: is.na

### DIFF
--- a/09-recodages.Rmd
+++ b/09-recodages.Rmd
@@ -136,9 +136,9 @@ vec %in% c("Jaune", "Vert")
 ```
 
 ```{block type='rmdimportant'}
-Attention, si on souhaite tester si une valeur est égale à `NA`, faire `x == NA` *ne fonctionnera pas*. En effet, fidèle à sa réputation de rigueur informaticienne, pour R `NA == NA` ne vaut pas `TRUE` mais... `NA`.
+Attention, si on souhaite tester si une valeur `x` est inconnue (ou 'manquante'), c'est-à-dire si elle est codée `NA` (*Not Available*), faire le test `x == NA` *ne donnera pas le résultat escompté*. En effet, fidèle à sa réputation de rigueur informaticienne, pour R `NA == NA` ne vaut pas `TRUE` mais... `NA`. (Est-ce qu'une valeur inconnue est égale à une autre valeur inconnue? On ne sait pas).
 
-Pour tester l'égalité avec `NA`, il faut utiliser la fonction dédiée `is.na` et faire `is.na(x)`.
+Pour tester si une valeur est inconnue (`NA`), il faut utiliser la fonction dédiée `is.na` et faire `is.na(x)`.
 ```
 
 


### PR DESCRIPTION
Plutôt que "tester l’égalité avec NA", il semble plus rigoureux d'écrire: "tester si une valeur est inconnue (`NA`)"