### PR TITLE
%in%,  match et NA

### DIFF
--- a/09-recodages.Rmd
+++ b/09-recodages.Rmd
@@ -129,7 +129,7 @@ vec <- c("Jaune", "Jaune", "Rouge", "Vert")
 vec == "Jaune" | vec == "Vert"
 ```
 
-À noter que dans ce cas, on peut utiliser l'opérateur `%in%`, qui teste si une valeur fait partie des éléments d'un vecteur :
+À noter que dans ce cas, on peut utiliser l'opérateur `%in%` (fonction `match()`), qui teste si une valeur fait partie des éléments d'un vecteur :
 
 ```{r}
 vec %in% c("Jaune", "Vert")
@@ -139,6 +139,8 @@ vec %in% c("Jaune", "Vert")
 Attention, si on souhaite tester si une valeur est égale à `NA`, faire `x == NA` *ne fonctionnera pas*. En effet, fidèle à sa réputation de rigueur informaticienne, pour R `NA == NA` ne vaut pas `TRUE` mais... `NA`.
 
 Pour tester l'égalité avec `NA`, il faut utiliser la fonction dédiée `is.na` et faire `is.na(x)`.
+
+Cependant, par convention, `NA %in% NA` vaut `TRUE`.
 ```
 
 


### PR DESCRIPTION
Le texte fait un parallèle entre vec == "Jaune" | vec == "Vert" et vec %in% c("Jaune", "Vert"). Ce parallèle est faut pour NA %in% NA. Mentionner le nom de la fonction (match) permet au lecteur de trouver plus facilement la documentation.