### PR TITLE
Correction d'une coquille dans 07-import.qmd

### DIFF
--- a/07-import.qmd
+++ b/07-import.qmd
@@ -277,7 +277,7 @@ Par ailleurs, depuis la version 1.1, RStudio facilite la connexion à certaines 
 
 On peut avoir besoin d'exporter un tableau de données dans R vers un fichier dans différents formats. La plupart des fonctions d'import disposent d'un équivalent permettant l'export de données. On citera notamment :
 
-- `write_csv`, `write_csv2`, `read_tsv` permettent d'enregistrer un *data frame* ou un tibble dans un fichier au format texte délimité
+- `write_csv`, `write_csv2`, `write_tsv` permettent d'enregistrer un *data frame* ou un tibble dans un fichier au format texte délimité
 - `write_sas` permet d'exporter au format SAS
 - `write_sav` permet d'exporter au format SPSS
 - `write_dta` permet d'exporter au format Stata


### PR DESCRIPTION
Dans la partie `Export de tableaux de données`, la fonction `read_tsv` était listée alors que c'est probablement `write_tsv` qui doit être utilisée dans ce contexte.